### PR TITLE
Update check_process for CI tests

### DIFF
--- a/check_process
+++ b/check_process
@@ -6,17 +6,17 @@
 ;; Test complet
 	; Manifest
 		domain="domain.tld"	(DOMAIN)
-		path="/"	(PATH)	
+		path="/pterodactyl"	(PATH)	
 		is_public=1	(PUBLIC|public=1|private=0)
-#		password="pass"
-#		nextclouddomain="domain.tld"
+		password="pass"
+                admin="john"    (USER)
 		port="9980"	(PORT)
 	; Checks
 		pkg_linter=1
-		setup_sub_dir=0
+		setup_sub_dir=1
 		setup_root=1
 		setup_nourl=0
-		setup_private=0
+		setup_private=1
 		setup_public=1
 		upgrade=1
 		backup_restore=1
@@ -27,10 +27,8 @@
 ;;; Levels
 	Level 1=auto
 	Level 2=auto
-	Level 3=auto
-# Level 4: 
-	Level 4=1 (This app supports the Nextcloud LDAP auth)
-# Level 5: 
+	Level 3=auto 
+	Level 4=auto
 	Level 5=auto
 	Level 6=auto
 	Level 7=auto


### PR DESCRIPTION
I updated check_process so you can use the [YunoHost CI](https://yunohost.org/#/packaging_apps_ci).
I already have an account with my rewrite on it (`pterodactyl_ynh`), I also pushed the current app but the build fails (look at `pterodactold_ynh` on the CI)